### PR TITLE
Fixed 2 bugs

### DIFF
--- a/src/main/java/amerifrance/guideapi/gui/GuiCategory.java
+++ b/src/main/java/amerifrance/guideapi/gui/GuiCategory.java
@@ -169,11 +169,15 @@ public class GuiCategory extends GuiBase {
     }
 
     public void nextPage() {
+        if(entryPage >= entryWrapperMap.asMap().size())
+            entryPage = entryWrapperMap.asMap().size() - 1;
         if (entryPage != entryWrapperMap.asMap().size() - 1 && !entryWrapperMap.asMap().isEmpty())
             entryPage++;
     }
 
     public void prevPage() {
+        if(entryPage >= entryWrapperMap.asMap().size())
+            entryPage = entryWrapperMap.asMap().size() - 1;
         if (entryPage != 0)
             entryPage--;
     }

--- a/src/main/java/amerifrance/guideapi/gui/GuiEntry.java
+++ b/src/main/java/amerifrance/guideapi/gui/GuiEntry.java
@@ -50,6 +50,7 @@ public class GuiEntry extends GuiBase {
     @Override
     public void initGui() {
         super.initGui();
+        entry.onInit(book, category, null, player, bookStack);
         this.buttonList.clear();
         this.pageWrapperList.clear();
 


### PR DESCRIPTION
*Fixed a crash when clicking the next/prev page buttons and the book is
on a page number that no longer exists (for example due to the contents
of the entry being changed in an update)

*Made onInit in EntryAbstract always be called at least once when an
entry's contents is viewed, to allow for changes to be applied without
closing and reopening the entry from the catagory GUI