### PR TITLE
fix crash with shapeless recipe

### DIFF
--- a/src/main/java/amerifrance/guideapi/page/reciperenderer/ShapelessRecipesRenderer.java
+++ b/src/main/java/amerifrance/guideapi/page/reciperenderer/ShapelessRecipesRenderer.java
@@ -29,17 +29,18 @@ public class ShapelessRecipesRenderer extends BasicRecipeRenderer<ShapelessRecip
                 int i = 3 * y + x;
                 int stackX = (x + 1) * 17 + (guiLeft + 27) + x;
                 int stackY = (y + 1) * 17 + (guiTop + 38) + y;
-
-                Ingredient ingredient = recipe.getIngredients().get(i);
-                List<ItemStack> list = Arrays.asList(ingredient.getMatchingStacks());
-                if (!list.isEmpty()) {
-                    ItemStack stack = list.get(getRandomizedCycle(x + (y * 3), list.size()));
-                    if (stack.getItemDamage() == OreDictionary.WILDCARD_VALUE)
-                        stack = getNextItem(stack, x);
-
-                    GuiHelper.drawItemStack(stack, stackX, stackY);
-                    if (GuiHelper.isMouseBetween(mouseX, mouseY, stackX, stackY, 15, 15))
-                        tooltips = GuiHelper.getTooltip(stack);
+                if(i <  recipe.getIngredients().size()){
+                  Ingredient ingredient = recipe.getIngredients().get(i);
+                  List<ItemStack> list = Arrays.asList(ingredient.getMatchingStacks());
+                  if (!list.isEmpty()) {
+                      ItemStack stack = list.get(getRandomizedCycle(x + (y * 3), list.size()));
+                      if (stack.getItemDamage() == OreDictionary.WILDCARD_VALUE)
+                          stack = getNextItem(stack, x);
+  
+                      GuiHelper.drawItemStack(stack, stackX, stackY);
+                      if (GuiHelper.isMouseBetween(mouseX, mouseY, stackX, stackY, 15, 15))
+                          tooltips = GuiHelper.getTooltip(stack);
+                  }
                 }
             }
         }

--- a/src/main/java/amerifrance/guideapi/test/TestBook.java
+++ b/src/main/java/amerifrance/guideapi/test/TestBook.java
@@ -55,8 +55,8 @@ public class TestBook implements IGuideBook {
                         "ingotIron", "ingotIron", "ingotIron",
                        "ingotIron", "ingotIron", "ingotIron"));
 
-        pages.add(PageIRecipe.newShapeless(new ItemStack(Blocks.LOG), 
-                        new ItemStack(Blocks.PLANKS, 4)));
+        pages.add(PageIRecipe.newShapeless(new ItemStack(Blocks.PLANKS, 4), 
+                        new ItemStack(Blocks.LOG)));
 
         categories.add(new CategoryItemStack(entries, "test.category.name", new ItemStack(Items.BANNER)));
         book.setCategoryList(categories);

--- a/src/main/java/amerifrance/guideapi/test/TestBook.java
+++ b/src/main/java/amerifrance/guideapi/test/TestBook.java
@@ -20,7 +20,7 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.oredict.ShapedOreRecipe;
-
+import net.minecraftforge.oredict.ShapelessOreRecipe;
 import javax.annotation.Nullable;
 import java.awt.Color;
 import java.util.List;
@@ -50,6 +50,14 @@ public class TestBook implements IGuideBook {
         pages.add(PageIRecipe.newShaped(new ItemStack(Items.ACACIA_BOAT), "X X", "XXX", 'X', "plankWood"));
         Entry entry = new EntryItemStack(pages, "test.entry.name", new ItemStack(Items.POTATO));
         entries.put(new ResourceLocation("guideapi", "entry"), entry);
+        
+        pages.add(PageIRecipe.newShapeless(new ItemStack(Blocks.IRON_BLOCK), 
+                        "ingotIron", "ingotIron", "ingotIron",
+                        "ingotIron", "ingotIron", "ingotIron",
+                       "ingotIron", "ingotIron", "ingotIron"));
+
+        pages.add(PageIRecipe.newShapeless(new ItemStack(Blocks.LOG), 
+                        new ItemStack(Blocks.PLANKS, 4)));
 
         categories.add(new CategoryItemStack(entries, "test.category.name", new ItemStack(Items.BANNER)));
         book.setCategoryList(categories);

--- a/src/main/java/amerifrance/guideapi/test/TestBook.java
+++ b/src/main/java/amerifrance/guideapi/test/TestBook.java
@@ -20,7 +20,6 @@ import net.minecraftforge.fml.common.registry.GameRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import net.minecraftforge.oredict.ShapedOreRecipe;
-import net.minecraftforge.oredict.ShapelessOreRecipe;
 import javax.annotation.Nullable;
 import java.awt.Color;
 import java.util.List;


### PR DESCRIPTION
Sorry i didnt test this very closely in the inital update.

So fixed the issue with shapeless, plus i made two test recipes in TestBook.

One maximum size with ore dictionary items, one quite small with regular items.  This should cover all the bases.  Original crash log:

java.lang.IndexOutOfBoundsException: Index: 3, Size: 3
at java.util.ArrayList.rangeCheck(Unknown Source)
at java.util.ArrayList.get(Unknown Source)
at net.minecraft.util.NonNullList.get(NonNullList.java:51)
at amerifrance.guideapi.page.reciperenderer.ShapelessRecipesRenderer.draw(ShapelessRecipesRenderer.java:33)
at amerifrance.guideapi.page.PageIRecipe.draw(PageIRecipe.java:59)
at amerifrance.guideapi.wrapper.PageWrapper.draw(PageWrapper.java:50)
at amerifrance.guideapi.gui.GuiEntry.drawScreen(GuiEntry.java:82)
at net.minecraftforge.client.ForgeHooksClient.drawScreen(ForgeHooksClient.java:382)
at net.minecraft.client.renderer.EntityRenderer.updateCameraAndRender(EntityRenderer.java:1168)
at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1192)
at net.minecraft.client.Minecraft.run(Minecraft.java:436)
at net.minecraft.client.main.Main.main(Main.java:118)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)