### PR TITLE
Should fix The-Fireplace/Mechanical-Soldiers#9

### DIFF
--- a/src/main/java/amerifrance/guideapi/page/reciperenderer/ShapedOreRecipeRenderer.java
+++ b/src/main/java/amerifrance/guideapi/page/reciperenderer/ShapedOreRecipeRenderer.java
@@ -45,7 +45,7 @@ public class ShapedOreRecipeRenderer extends BasicRecipeRenderer<ShapedOreRecipe
                 if (component != null) {
                     if (component instanceof ItemStack) {
                         ItemStack input = (ItemStack) component;
-                        if (input.getItemDamage() == OreDictionary.WILDCARD_VALUE)
+                        if (input.getItem() != null && input.getItemDamage() == OreDictionary.WILDCARD_VALUE)
                             input.setItemDamage(0);
 
                         GuiHelper.drawItemStack((ItemStack) component, stackX, stackY);


### PR DESCRIPTION
That crash should have been impossible, because an ItemStack's item should never be null, but for some reason, it looks like that's what it was. That is the only possible null in the line of code the crash report pointed to, the stack was null checked.