### PR TITLE
Reverted removal of methods in GuiBase

### DIFF
--- a/src/main/java/amerifrance/guideapi/gui/GuiBase.java
+++ b/src/main/java/amerifrance/guideapi/gui/GuiBase.java
@@ -98,4 +98,14 @@ public class GuiBase extends GuiScreen {
         RenderHelper.enableStandardItemLighting();
         enableLighting();
     }
+
+    @Override
+    public void renderToolTip(ItemStack stack, int x, int y) {
+        super.renderToolTip(stack, x, y);
+    }
+
+    @Override
+    public void onGuiClosed() {
+        super.onGuiClosed();
+    }
 }


### PR DESCRIPTION
By removing these methods, many pages in the Blood Magic book would crash the game when viewed. This pull request undoes the removal of those methods.