### PR TITLE
Go to the category page the item is on

### DIFF
--- a/src/main/java/amerifrance/guideapi/api/impl/Category.java
+++ b/src/main/java/amerifrance/guideapi/api/impl/Category.java
@@ -43,7 +43,7 @@ public class Category extends CategoryAbstract {
     @Override
     @SideOnly(Side.CLIENT)
     public void onLeftClicked(Book book, int mouseX, int mouseY, EntityPlayer player, ItemStack bookStack) {
-        Minecraft.getMinecraft().displayGuiScreen(new GuiCategory(book, this, player, bookStack));
+        Minecraft.getMinecraft().displayGuiScreen(new GuiCategory(book, this, player, bookStack, null));
     }
 
     @Override

--- a/src/main/java/amerifrance/guideapi/gui/GuiCategory.java
+++ b/src/main/java/amerifrance/guideapi/gui/GuiCategory.java
@@ -24,6 +24,8 @@ import java.awt.Color;
 import java.io.IOException;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 public class GuiCategory extends GuiBase {
 
     public ResourceLocation outlineTexture;
@@ -35,14 +37,16 @@ public class GuiCategory extends GuiBase {
     public ButtonNext buttonNext;
     public ButtonPrev buttonPrev;
     public int entryPage;
+    @Nullable public EntryAbstract startEntry;
 
-    public GuiCategory(Book book, CategoryAbstract category, EntityPlayer player, ItemStack bookStack) {
+    public GuiCategory(Book book, CategoryAbstract category, EntityPlayer player, ItemStack bookStack, @Nullable EntryAbstract startEntry) {
         super(player, bookStack);
         this.book = book;
         this.category = category;
         this.pageTexture = book.getPageTexture();
         this.outlineTexture = book.getOutlineTexture();
         this.entryPage = 0;
+        this.startEntry = startEntry;
     }
 
     @Override
@@ -66,6 +70,10 @@ public class GuiCategory extends GuiBase {
         for (EntryAbstract entry : entries) {
             entry.onInit(book, category, this, player, bookStack);
             entryWrapperMap.put(pageNumber, new EntryWrapper(this, book, category, entry, eX, eY, 4 * xSize / 6, 10, player, this.fontRenderer, bookStack));
+            if (entry.equals(this.startEntry)) {
+                this.startEntry = null;
+                this.entryPage = pageNumber;
+            }
             eY += 13;
             i++;
 

--- a/src/main/java/amerifrance/guideapi/gui/GuiEntry.java
+++ b/src/main/java/amerifrance/guideapi/gui/GuiEntry.java
@@ -108,7 +108,7 @@ public class GuiEntry extends GuiBase {
         }
 
         if (typeofClick == 1) {
-            this.mc.displayGuiScreen(new GuiCategory(book, category, player, bookStack));
+            this.mc.displayGuiScreen(new GuiCategory(book, category, player, bookStack, entry));
         }
     }
 
@@ -127,7 +127,7 @@ public class GuiEntry extends GuiBase {
     public void keyTyped(char typedChar, int keyCode) {
         super.keyTyped(typedChar, keyCode);
         if (keyCode == Keyboard.KEY_BACK || keyCode == this.mc.gameSettings.keyBindUseItem.getKeyCode())
-            this.mc.displayGuiScreen(new GuiCategory(book, category, player, bookStack));
+            this.mc.displayGuiScreen(new GuiCategory(book, category, player, bookStack, entry));
         if ((keyCode == Keyboard.KEY_UP || keyCode == Keyboard.KEY_RIGHT) && pageNumber + 1 < pageWrapperList.size())
             nextPage();
         if ((keyCode == Keyboard.KEY_DOWN || keyCode == Keyboard.KEY_LEFT) && pageNumber > 0)
@@ -137,7 +137,7 @@ public class GuiEntry extends GuiBase {
     @Override
     public void actionPerformed(GuiButton button) {
         if (button.id == 0)
-            this.mc.displayGuiScreen(new GuiCategory(book, category, player, bookStack));
+            this.mc.displayGuiScreen(new GuiCategory(book, category, player, bookStack, entry));
         else if (button.id == 1 && pageNumber + 1 < pageWrapperList.size())
             nextPage();
         else if (button.id == 2 && pageNumber > 0)

--- a/src/main/java/amerifrance/guideapi/proxy/CommonProxy.java
+++ b/src/main/java/amerifrance/guideapi/proxy/CommonProxy.java
@@ -44,7 +44,7 @@ public class CommonProxy implements IGuiHandler {
                     } else if (tagCompound.hasKey(NBTBookTags.CATEGORY_TAG)) {
                         CategoryAbstract category = book.getCategoryList().get(tagCompound.getInteger(NBTBookTags.CATEGORY_TAG));
                         int entryPage = tagCompound.getInteger(NBTBookTags.ENTRY_PAGE_TAG);
-                        GuiCategory guiCategory = new GuiCategory(book, category, player, bookStack);
+                        GuiCategory guiCategory = new GuiCategory(book, category, player, bookStack, null);
                         guiCategory.entryPage = entryPage;
                         return guiCategory;
                     } else {


### PR DESCRIPTION
When returning from an item to a category, go to the page that has that item instead of always going to page 1. This makes it much easier to browse through several items in a row several pages into a category.